### PR TITLE
Declare Session interface manually with userId (prevents typescript errors)

### DIFF
--- a/packages/auth-template/src/resolvers/AuthResolver.ts
+++ b/packages/auth-template/src/resolvers/AuthResolver.ts
@@ -5,6 +5,12 @@ import { AuthInput } from "../graphql-types/AuthInput";
 import { MyContext } from "../graphql-types/MyContext";
 import { UserResponse } from "../graphql-types/UserResponse";
 
+declare module 'express-session' {
+  interface Session {
+      userId: number
+  }
+}
+
 const invalidLoginResponse = {
   errors: [
     {


### PR DESCRIPTION
Reason for this PR:

When I run `yarn start` I get issues with the session's user ID:

```
C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:293
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/resolvers/AuthResolver.ts:61:26 - error TS2339: Property 'userId' does not exist on type 'Session & Partial<SessionData>'.

61         ctx.req.session!.userId = user.id
                            ~~~~~~
src/resolvers/AuthResolver.ts:68:31 - error TS2339: Property 'userId' does not exist on type 'Session & Partial<SessionData>'.

68         if (!ctx.req.session!.userId) {
                                 ~~~~~~
src/resolvers/AuthResolver.ts:72:46 - error TS2339: Property 'userId' does not exist on type 'Session & Partial<SessionData>'.

72         return User.findOne(ctx.req.session!.userId)
                                                ~~~~~~

    at createTSError (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:293:12)
    at reportTSError (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:297:19)
    at getOutput (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:399:34)
    at Object.compile (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:457:32)
    at Module.m._compile (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:530:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Object.require.extensions.<computed> [as .ts] (C:\Users\Taimoor\Desktop\Code\selfroad-api\node_modules\ts-node\src\index.ts:533:12)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
[nodemon] app crashed - waiting for file changes before starting...
```

I looked at this [GitHub issue](https://github.com/expressjs/session/issues/792) and managed to fix it. 