### PR TITLE
Updated versions for pg & typeorm

### DIFF
--- a/packages/auth-template/package.json
+++ b/packages/auth-template/package.json
@@ -17,11 +17,11 @@
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "graphql": "^14.5.8",
-    "pg": "^7.13.0",
+    "pg": "8.0.3",
     "reflect-metadata": "^0.1.10",
     "sqlite3": "^4.1.0",
     "type-graphql": "^0.17.5",
-    "typeorm": "0.2.20"
+    "typeorm": "0.2.21"
   },
   "scripts": {
     "start": "nodemon --exec ts-node --files src/index.ts",

--- a/packages/main-template/package.json
+++ b/packages/main-template/package.json
@@ -12,11 +12,11 @@
     "apollo-server-express": "^2.9.9",
     "express": "^4.17.1",
     "graphql": "^14.5.8",
-    "pg": "^7.13.0",
+    "pg": "8.0.3",
     "reflect-metadata": "^0.1.10",
     "sqlite3": "^4.1.0",
     "type-graphql": "^0.17.5",
-    "typeorm": "0.2.20"
+    "typeorm": "0.2.21"
   },
   "scripts": {
     "start": "nodemon --exec ts-node src/index.ts",


### PR DESCRIPTION
Updating `pg` and `typeorm` to fix issues with using Postgres in production.

# Issue

- (In node 14) When switching to the production configuration using Postgres `typeorm` fails to make a connection to the database w/o exiting or throwing an exception. As described in  typeorm/typeorm#5949
- Current `typeorm` version incompatible with Postgres 12+.  typeorm/typeorm#4332

# Fix
- Upgrade `pg` to `8.0.3`
- Upgrade `typeorm` to `0.2.21`